### PR TITLE
Make the vibe.d dependency optional.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
 	"copyright": "Copyright © 2013 Piotr Szturmaj",
 	"homepage": "https://github.com/pszturmaj/",
 	"authors": ["Piotr Szturmaj"],
-	"targetType": "sourceLibrary",
 	"dependencies": {
-		"vibe-d": {"version":"~master"}
-	},
-	"versions": ["Have_vibe_d"]
+		"vibe-d": {"version": "~master", "optional": true}
+	}
 }


### PR DESCRIPTION
Just a little cleanup. I didn't see this at first, but `Have_vibe_d` is defined automatically by DUB, so there is no need to define it manually. Also, the `vibe-d` dependency is now optional and there is no need to force the library to be a "sourceLibrary".
