### PR TITLE
Ensure module names and path names are consistent

### DIFF
--- a/source/ddb/db.d
+++ b/source/ddb/db.d
@@ -1,4 +1,4 @@
-module postgres.ops;
+module ddb.db;
 
 /**
 Common relational database interfaces.

--- a/source/ddb/postgres.d
+++ b/source/ddb/postgres.d
@@ -1,4 +1,4 @@
-module postgres.db;
+module ddb.postgres;
 
 /**
 PostgreSQL client implementation.
@@ -174,7 +174,7 @@ import std.variant;
 import std.algorithm;
 import std.stdio;
 import std.datetime;
-public import postgres.ops;
+public import ddb.db;
 
 private:
 

--- a/source/postgres/db.d
+++ b/source/postgres/db.d
@@ -1,0 +1,12 @@
+module postgres.db;
+
+// This file supports backwards compatibility only.
+// Use `import ddb.postgres;` for new code
+
+public import ddb.postgres;
+
+import std.stdio;
+
+shared static this() {
+    stderr.writeln("WARNING: Module postgres.db deprecated. Replace with module ddb.postgres");
+}


### PR DESCRIPTION
DUB builds each package separately, and then adds each package to the
import paths using D's usual mechanism of generating the filesystem
path name from the module name.  To make this work, source files must
be in a path that matches the module name.

Create a module at postgres/db.d to avoid breaking existing code that
imports postgres.db. This module prints a deprecation warning and
re-exports the contents of ddb.postgres.
