### PR TITLE
Resolve name conflict from GDC libraries

### DIFF
--- a/source/ddb/postgres.d
+++ b/source/ddb/postgres.d
@@ -1362,8 +1362,9 @@ class PGConnection
                     string tag;
                     
                     msg.readCString(tag);
-                    
-                    auto s1 = indexOf(tag, ' ');
+
+                    // GDC indexOf name conflict in std.string and std.algorithm                    
+                    auto s1 = std.string.indexOf(tag, ' ');
                     if (s1 >= 0) {
                         switch (tag[0 .. s1]) {
                             case "INSERT":


### PR DESCRIPTION
GDC version of Phobos defines a deprecated version of indexOf in
std.algorithm.  The suggested fix is to use std.algorithm.countUntil,
but as we're dealing with pure ASCII text, the original std.string.indexOf
is fine for our purposes. So we simply name usage of indexOf with a fully
qualified name.
