### PR TITLE
SysTime structures are not to be considered a composite type.

### DIFF
--- a/source/ddb/db.d
+++ b/source/ddb/db.d
@@ -309,7 +309,8 @@ $(UL
 */
 template isCompositeType(T)
 {
-    static if (isTuple!T || is(T == struct) || isStaticArray!T)
+    import std.datetime : SysTime;
+    static if (isTuple!T || (is(T == struct) && !(is(T == SysTime))) || isStaticArray!T)
         enum isCompositeType = true;
     else
         enum isCompositeType = false;


### PR DESCRIPTION
Actually the library is trying to read and fill the single fields of the SysTime structure.