### PR TITLE
Sync statement to the backend when an error is received in ...

### DIFF
--- a/source/ddb/postgres.d
+++ b/source/ddb/postgres.d
@@ -1244,6 +1244,7 @@ class PGConnection
                 case 'E':
                     // ErrorResponse
                     ResponseMessage response = handleResponseMessage(msg);
+                    sendSyncMessage();
                     throw new ServerErrorException(response);
                 case '1':
                     // ParseComplete
@@ -1296,6 +1297,7 @@ class PGConnection
                 case 'E':
                     // ErrorResponse
                     ResponseMessage response = handleResponseMessage(msg);
+                    sendSyncMessage();
                     throw new ServerErrorException(response);
                 case '3':
                     // CloseComplete


### PR DESCRIPTION
...an extended query, prior to throw an exception.

Let's say we have a db with a table like:

```
   CREATE TABLE foo (bar SMALLINT);
```

And I try to do something like this (as an example):

```
try {
    auto cmd = new PGCommand(pgConnection, "BEGIN TRANSACTION");
    cmd.executeNonQuery();
    cmd = new PGCommand(pgConnection, "UPDATE foo SET baz=42");
    cmd.executeNonQuery();
    cmd = new PGCommand(pgConnection, "COMMIT TRANSACTION");
    cmd.executeNonQuery();
}
catch(ServerErrorException e){
    cmd = new PGCommand(pgConnection, "ABORT TRANSACTION");
    cmd.executeNonQuery();
}
```

As the thrown is done during the parse phase of the extended query:

```
ddb.postgres.ServerErrorException@ddb/source/ddb/postgres.d(860): ERROR 42703: column "baz" does not exists
```

the backend will ignore every other message till a sync, so actually the abort command will not be executed, as the application hangs in the socket waiting for some reply that will never come back.

It seems to me that a 'sendSyncMessage()' must be added before throwing the ServerException, closing in that way the extended query.
