### PR TITLE
Implementation of VARCHAR and FLOAT8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .dub
-libddb.a
+*.a

--- a/source/ddb/postgres.d
+++ b/source/ddb/postgres.d
@@ -1111,6 +1111,7 @@ class PGConnection
                     case PGType.INT2: checkParam!short(2); break;
                     case PGType.INT4: checkParam!int(4); break;
                     case PGType.INT8: checkParam!long(8); break;
+                    case PGType.VARCHAR:
                     case PGType.TEXT:
                         paramsLen += param.value.coerce!string.length;
                         hasText = true;
@@ -1162,6 +1163,7 @@ class PGConnection
                         stream.write(cast(int)8);
                         stream.write(param.value.coerce!long);
                         break;
+                    case PGType.VARCHAR:
                     case PGType.TEXT:
                         auto s = param.value.coerce!string;
                         stream.write(cast(int) s.length);

--- a/source/ddb/postgres.d
+++ b/source/ddb/postgres.d
@@ -1108,6 +1108,7 @@ class PGConnection
                 
                 /*final*/ switch (param.type)
                 {
+                    case PGType.FLOAT8: checkParam!double(8); break;
                     case PGType.INT2: checkParam!short(2); break;
                     case PGType.INT4: checkParam!int(4); break;
                     case PGType.INT8: checkParam!long(8); break;
@@ -1151,6 +1152,10 @@ class PGConnection
                 
                 switch (param.type)
                 {
+                    case PGType.FLOAT8:
+                        stream.write(cast(int)8);
+                        stream.write(param.value.coerce!double);
+                        break;
                     case PGType.INT2:
                         stream.write(cast(int)2);
                         stream.write(param.value.coerce!short);

--- a/source/ddb/postgres.d
+++ b/source/ddb/postgres.d
@@ -1115,7 +1115,7 @@ class PGConnection
                         paramsLen += param.value.coerce!string.length;
                         hasText = true;
                         break;
-                    default: assert(0, "Not implemented");
+                    default: assert(0, to!string(param.type) ~ " Not implemented");
                 }
             }
             
@@ -1168,7 +1168,7 @@ class PGConnection
                         stream.write(cast(ubyte[]) s);
                         break;
                     default:
-						assert(0, "Not implemented");
+                    assert(0, to!string(param.type) ~ "Not implemented");
                 }
             }
             


### PR DESCRIPTION
Added implementation of VARCHAR and FLOAT8/DOUBLE PRECISION types. VARCHAR sumply using same check and stream writing as TEXT. FLOAT8 uses 8 bytes as a double.