### PR TITLE
avoid to read from socket if we know that there's nothing to read

### DIFF
--- a/source/ddb/postgres.d
+++ b/source/ddb/postgres.d
@@ -1011,9 +1011,12 @@ class PGConnection
 
 			len = bigEndianToNative!int(ubi) - 4;
             
-            ubyte[] msg = new ubyte[len];
-
-            stream.socket.read(msg);
+            ubyte[] msg = [];
+            if(len>0)
+            {
+                msg = new ubyte[len];
+                stream.socket.read(msg);
+            }
             
             return Message(this, type, msg);
         }


### PR DESCRIPTION
the actual strategy triggers an assert in the libasync vibe driver, as the read function is checking for null buffer as arguments:
  core.exception.AssertError@prj/../github/vibe.d/source/vibe/core/drivers/libasync.d(1122): Assertion failure
  ----------------
  prj/bin/phosvc_l64_g_ud() [0x675486]
  prj/bin/phosvc_l64_g_ud() [0x5f3172]
  prj/bin/phosvc_l64_g_ud() [//prj/../github/vibe.d/source/vibe/core/drivers/libasync.d:1123]
  prj/bin/phosvc_l64_g_ud() [//prj/../github/ddb/source/ddb/postgres.d:1018]
  prj/bin/phosvc_l64_g_ud() [//prj/../github/ddb/source/ddb/postgres.d:1270]
  prj/bin/phosvc_l64_g_ud() [//prj/../github/ddb/source/ddb/postgres.d:2069]
  prj/bin/phosvc_l64_g_ud() [//prj/../github/ddb/source/ddb/postgres.d:2113]
  prj/bin/phosvc_l64_g_ud() [//prj/../github/ddb/source/ddb/postgres.d:1759]
  prj/bin/phosvc_l64_g_ud() [//prj/../github/ddb/source/ddb/postgres.d:1834]
  prj/bin/phosvc_l64_g_ud() [//prj/../github/ddb/source/ddb/postgres.d:1714]
  prj/bin/phosvc_l64_g_ud() [//prj/phosvc/src/mailuseragent.d:285]
  prj/bin/phosvc_l64_g_ud() [//prj/../github/vibe.d/source/vibe/core/core.d:472]
  prj/bin/phosvc_l64_g_ud() [//prj/../github/vibe.d/source/vibe/core/core.d:970]
  prj/bin/phosvc_l64_g_ud() [0x6af716]
  prj/bin/phosvc_l64_g_ud() [0x6af605]```