### PR TITLE
in the isNullable template check also against std.typecons.Nullable

### DIFF
--- a/source/ddb/db.d
+++ b/source/ddb/db.d
@@ -344,7 +344,10 @@ static assert(isVariantN!(Nullable!int));
 
 template isNullable(T)
 {
-    static if ((isVariantN!T && T.allowed!(void*)) || is(T X == Nullable!U, U))
+    alias STN = std.typecons.Nullable;
+    alias DDN = .Nullable;
+
+    static if ((isVariantN!T && T.allowed!(void*)) || is(T X == DDN!U, U) || is(T X == STN!U, U))
         enum isNullable = true;
     else
         enum isNullable = false;


### PR DESCRIPTION
actually the template fails to return true if a struct is using the std.typecons.isNullable (dmd 2.067.1):

```D
import std.typecons;
struct Foo { Nullable!(ubyte[]) bar; }
