### PR TITLE
assert failure in libasync calling write on socket with an empty ubyte[] array.

### DIFF
--- a/source/ddb/postgres.d
+++ b/source/ddb/postgres.d
@@ -1218,7 +1218,7 @@ class PGConnection
                     case PGType.TEXT:
                         auto s = param.value.coerce!string;
                         stream.write(cast(int) s.length);
-                        stream.write(cast(ubyte[]) s);
+                        if(s.length) stream.write(cast(ubyte[]) s);
                         break;
                     case PGType.BYTEA:
                         auto s = param.value;


### PR DESCRIPTION
When an empty string is bond as a parameter, I've this stack trace:

```
core.exception.AssertError@../../../../.dub/packages/vibe-d-0.8.0-beta.3/vibe-d/core/vibe/core/drivers/libasync.d(1269): Assertion failure
----------------
4   mars                                0x000000010a8121d4 _d_assert + 104
5   mars                                0x000000010a71c761 void vibe.core.drivers.libasync.__assert(int) + 41
6   mars                                0x000000010a724b87 @trusted ulong vibe.core.drivers.libasync.LibasyncTCPConnection.write(const(ubyte[]), vibe.core.stream.IOMode) + 131
7   mars                                0x000000010a76802e @safe void vibe.core.stream.OutputStream.write(const(ubyte[])) + 106
8   mars                                0x000000010a6049dc void ddb.postgres.PGStream.write(ubyte[]) + 144

9   mars                                0x000000010a60713a D3ddb8postgres12PGConnection15sendBindMessageMFAyaAyaC3ddb8postgres12PGParametersZ14__foreachbody6MFKC3ddb8postgres11PGParameterZi + 1186
```

We can safely avoid to write the value of the text parameter, if the length of the string is zero.