### PR TITLE
fix #71 - pool a wrapped vibe.d TCPConnection

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -8,7 +8,7 @@
 
 	"dependencies": {
 		"vibe-d:core": {
-			"version": ">=0.7.29",
+			"version": "~>0.8.0",
 			"optional": true
 		}
 	}


### PR DESCRIPTION
...as there's no way to cleanup the pool if PostgreSQL restarts.

Right now I've tested it with vibe-d:core 0.8.0: can we update the dub.json to that?