### PR TITLE
Fix for corrupted connection parameters while exception unwinding

### DIFF
--- a/source/ddb/postgres.d
+++ b/source/ddb/postgres.d
@@ -1658,7 +1658,7 @@ class PGConnection
             enforce("host" in params, new ParamException("Required parameter 'host' not found"));
             enforce("user" in params, new ParamException("Required parameter 'user' not found"));
 
-            string[string] p = cast(string[string])params;
+            string[string] p = cast(string[string])params.dup;
 
             ushort port = "port" in params? parse!ushort(p["port"]) : 5432;
 


### PR DESCRIPTION
The AA params has to be dupped because otherwise the origin params AA in PostgresDB gets corrupted when connection cannot be established, i.e. an exception is thrown in the ctor.
The "port" property is set to an empty string in my case.