### PR TITLE
Don't modify params in PGConnection.this

### DIFF
--- a/source/ddb/postgres.d
+++ b/source/ddb/postgres.d
@@ -1661,9 +1661,7 @@ class PGConnection
             enforce("host" in params, new ParamException("Required parameter 'host' not found"));
             enforce("user" in params, new ParamException("Required parameter 'user' not found"));
 
-            string[string] p = cast(string[string])params.dup;
-
-            ushort port = "port" in params? parse!ushort(p["port"]) : 5432;
+            ushort port = "port" in params ? to!ushort(params["port"]) : 5432;
 
             version(Have_vibe_d_core)
             {


### PR DESCRIPTION
`std.conv.parse` takes input range by reference and slices it away. Doing so by casting away const is UB.